### PR TITLE
Update links to OpenFF Toolkit

### DIFF
--- a/2021-12-14-training-and-software.markdown
+++ b/2021-12-14-training-and-software.markdown
@@ -49,8 +49,8 @@ In this post, I'll link to a few training materials and software packages that m
 
 [ccpbiosim]: https://www.ccpbiosim.ac.uk/training
 [openff]: https://openforcefield.org
-[openff1]: https://open-forcefield-toolkit.readthedocs.io/en/0.10.1/users/molecule_cookbook.html
-[openff2]: https://github.com/openforcefield/openff-toolkit/tree/master/examples#examples-using-smirnoff-with-the-toolkit
+[openff1]: https://open-forcefield-toolkit.readthedocs.io/en/0.10.6/users/molecule_cookbook.html
+[openff2]: https://github.com/openforcefield/openff-toolkit/tree/0.10.6/examples#examples-using-smirnoff-with-the-toolkit
 [bespokefit]: https://www.youtube.com/watch?v=xQ8pnYcmWSU
 [bespokefit-github]: https://github.com/openforcefield/openff-bespokefit
 [teachopencadd]: https://projects.volkamerlab.org/teachopencadd/


### PR DESCRIPTION
Hi @djcole56 - I noticed a couple of very minor issues in your recent website update

* A couple of the links to OpenFF documentation were a bit out of sync. Pinning to the old (0.10.x) version is fine since BespokeFit does not yet work with 0.11.0, but there have been a couple of changes between 0.10.1 and 0.10.6 that might be useful to have in, especially if people do anything with virtual sites.
* The link to the examples points to the `master` branch, which is probably mostly in sync with version 0.10.6 but isn't strictly maintained (now that development happens on the `main` branch) and is liable to get deleted at some point.